### PR TITLE
Add manual trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
Since GitHub actions likes to have downtimes and sometimes forgets actions that should've run, this seems to be necessary