### PR TITLE
Object validators are not always required

### DIFF
--- a/README.md
+++ b/README.md
@@ -868,7 +868,7 @@ This example will validate to true for `true`, `false`, `"true"` and `"false"` a
 This validator is used when your data model is not flat and has objects with keys in it.  
 When the validation fails, it will return a dictionary with all the test results for its children in it.
 
-The object validator does not have any special methods.  
+The object validator does only has a single special method, which you are unlikely to need. (See below)
 However, it has to be constructed with the field's children as the first param.  
 It also accepts an additional param `dropEmpty`, which defaults to `true`.  
 This value can also be set after constructing using the `setDropEmpty` function on the validator.  
@@ -889,6 +889,9 @@ In addition to the regular `validate` function, the ObjectValidator also has a `
 This function allows you to validate all child fields that are neither Array nor ObjectValidators.  
 This can be useful if you only need to validate a subset of a form that is split in multiple steps, with those steps being sub fields of
 each other.
+
+Note that a non required ObjectValidator field will be treated as required if it has any children that are required.  
+To avoid this behaviour and allow empty objects, you may use the `notRequired` method.
 
 Example:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/plugin-transform-runtime": "^7.16.4",
         "@babel/preset-env": "^7.16.4",
         "@babel/preset-react": "^7.16.0",
-        "@binary-butterfly/eslint-config": "^0.0.4",
+        "@binary-butterfly/eslint-config": "^0.0.5",
         "@rollup/plugin-babel": "^5.3.0",
         "@rollup/plugin-commonjs": "^21.0.1",
         "@rollup/plugin-node-resolve": "^13.1.1",
@@ -1805,9 +1805,9 @@
       "dev": true
     },
     "node_modules/@binary-butterfly/eslint-config": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@binary-butterfly/eslint-config/-/eslint-config-0.0.4.tgz",
-      "integrity": "sha512-H0VLbTSSGZi1lY1ZZsPhiZYca3TVsPQJ/fWlhr7NftD+ZhHXMlUfNiazDbF5mTr7cK7Dv0m9/YTRhFF8DCeiLg==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@binary-butterfly/eslint-config/-/eslint-config-0.0.5.tgz",
+      "integrity": "sha512-+qj00lBsB7ZhCKBQUpllrkxjU/b0tXwG6QfyaQ5dUeMPPsk1m/RT+Ei1WPqKlvrm3CznCDF4V8rf+27k8DkUfw==",
       "dev": true,
       "peerDependencies": {
         "@babel/eslint-parser": "^7.18.2",
@@ -13886,9 +13886,9 @@
       "dev": true
     },
     "@binary-butterfly/eslint-config": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@binary-butterfly/eslint-config/-/eslint-config-0.0.4.tgz",
-      "integrity": "sha512-H0VLbTSSGZi1lY1ZZsPhiZYca3TVsPQJ/fWlhr7NftD+ZhHXMlUfNiazDbF5mTr7cK7Dv0m9/YTRhFF8DCeiLg==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@binary-butterfly/eslint-config/-/eslint-config-0.0.5.tgz",
+      "integrity": "sha512-+qj00lBsB7ZhCKBQUpllrkxjU/b0tXwG6QfyaQ5dUeMPPsk1m/RT+Ei1WPqKlvrm3CznCDF4V8rf+27k8DkUfw==",
       "dev": true,
       "requires": {}
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "formifly",
-  "version": "1.13.2",
+  "version": "1.14.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "formifly",
-      "version": "1.13.2",
+      "version": "1.14.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/plugin-transform-runtime": "^7.16.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formifly",
-  "version": "1.13.2",
+  "version": "1.14.0",
   "description": "React form handling as light as a butterfly",
   "main": "dist/umd/formifly.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@babel/plugin-transform-runtime": "^7.16.4",
     "@babel/preset-env": "^7.16.4",
     "@babel/preset-react": "^7.16.0",
-    "@binary-butterfly/eslint-config": "^0.0.4",
+    "@binary-butterfly/eslint-config": "^0.0.5",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-node-resolve": "^13.1.1",

--- a/src/js/__tests__/classes/ObjectValidator.test.js
+++ b/src/js/__tests__/classes/ObjectValidator.test.js
@@ -260,3 +260,28 @@ test('Test ObjectValidator validateWithoutRecursion', () => {
 
     expect(validator.validateWithoutRecursion(values)).toStrictEqual([true, values]);
 });
+
+test('Test ObjectValidator can validate empty objects successfully explicitly when not required', () => {
+    const validator = new ObjectValidator({banana: new StringValidator().required()}).notRequired();
+    expect(validator.validate({})).toStrictEqual([true, {}]);
+});
+
+test('Test ObjectValidator rejects empty objects if it is required', () => {
+    const validator = new ObjectValidator({banana: new StringValidator()}).required('This has to be set.');
+    expect(validator.validate({})).toStrictEqual([false, 'This has to be set.']);
+});
+
+test('Test ObjectValidator rejects empty objects if it has not been set to really not be required and a child field is required', () => {
+    const validator = new ObjectValidator({banana: new StringValidator().required('Bla')});
+    expect(validator.validate({})).toStrictEqual([false, {banana: [false, 'Bla']}]);
+});
+
+test('Test ObjectValidator rejects non set required child fields', () => {
+    const validator = new ObjectValidator({banana: new StringValidator().required('This has to be set.'), apple: new StringValidator()});
+    expect(validator.validate({apple: 'foo'})).toStrictEqual([false, {apple: [true, 'foo'], banana: [false, 'This has to be set.']}]);
+});
+
+test('Test ObjectValidator can handle undefined if explicitly not required', () => {
+    const validator = new ObjectValidator({foo: new StringValidator()}).notRequired();
+    expect(validator.validate(undefined)).toStrictEqual([true, undefined]);
+});

--- a/src/js/classes/ObjectValidator.js
+++ b/src/js/classes/ObjectValidator.js
@@ -12,6 +12,7 @@ class ObjectValidator extends BaseValidator {
     fields = {};
     dropEmpty;
     dropNotInShape;
+    reallyNotRequired;
 
     /**
      * @param {Object} fields
@@ -27,6 +28,16 @@ class ObjectValidator extends BaseValidator {
         this.fields = fields;
         this.dropEmpty = dropEmpty;
         this.dropNotInShape = dropNotInShape;
+    }
+
+    /**
+     * Sets the object validator as non required
+     * @returns {ObjectValidator}
+     */
+    notRequired() {
+        this.isRequired = false;
+        this.reallyNotRequired = true;
+        return this;
     }
 
     /**
@@ -56,6 +67,14 @@ class ObjectValidator extends BaseValidator {
         return ret;
     }
 
+    validateRequired(value) {
+        if (typeof value === 'object') {
+            return Object.keys(value).length > 0;
+        } else {
+            return super.validateRequired(value);
+        }
+    }
+
     /**
      * This function allows you to validate the ObjectValidator's child fields without validating any sub objects or array children.
      * @param {Object} value
@@ -68,6 +87,10 @@ class ObjectValidator extends BaseValidator {
     }
 
     validate(value, otherValues, siblings, recursion = true) {
+        if (this.reallyNotRequired && !this.validateRequired(value)) {
+            return [true, value];
+        }
+
         const preValidate = super.validate(value, otherValues, siblings);
         if (!preValidate[0]) {
             return preValidate;

--- a/src/js/components/meta/FormiflyContext.js
+++ b/src/js/components/meta/FormiflyContext.js
@@ -155,11 +155,11 @@ export const FormiflyProvider = (props) => {
      * Returns all properties needed to render a Formifly field.
      * Use this function if the AutomagicFormiflyField does not work for your specific use case.
      * @param {String} name - The field name. If it is a child field of an object write like this: objectName.key, if it is a child of an array write like this arrayName.index
-     * @param {String} [help] - Help text to display next to the field
-     * @param {String} [type] - The field's type. This will usually be filled in automatically, however with radio fields you need to pass it.
-     * @param {String} [value] - The field value. **Only used for radio fields**. This does not contain the value of the field within your data but instead the value of this specific radio option.
-     * @param {String} [id] - The field's id. Usually IDs will be automatically generated like this: formifly-input-field-$name (or formifly-input-field-$name-radio-$value for radio buttons). Only pass an id if you want to override this.
-     * @param {String} [additionalDescribedBy] - Use this to add additional ids to aria-describedby. (By default help and error displays are already connected.) This is especially useful when building a radio group without using the FormiflyRadioGroup component to add a title to the radio options.
+     * @param {String=} help - Help text to display next to the field
+     * @param {String=} type - The field's type. This will usually be filled in automatically, however with radio fields you need to pass it.
+     * @param {String=} value - The field value. **Only used for radio fields**. This does not contain the value of the field within your data but instead the value of this specific radio option.
+     * @param {String=} id - The field's id. Usually IDs will be automatically generated like this: formifly-input-field-$name (or formifly-input-field-$name-radio-$value for radio buttons). Only pass an id if you want to override this.
+     * @param {String=} additionalDescribedBy - Use this to add additional ids to aria-describedby. (By default help and error displays are already connected.) This is especially useful when building a radio group without using the FormiflyRadioGroup component to add a title to the radio options.
      * @return {{onBlur: (function(*): Promise<unknown>), onChange: handleChange, name, id: string, type: string, value, errors: (*|boolean), onFocus: handleFocus}}
      */
     const getFieldProps = (name, help, type, value, id, additionalDescribedBy) => {


### PR DESCRIPTION
This PR adds a method to allow ObjectValidators to not be required, even if they have required child fields.

The default behavior where ObjectValidators get their requiredness from their children may not necessarily be what people expect, but it is very useful in many cases.  
In cases where it becomes a problem, there is now the explicit `notRequired` method in ObjectValidators.

Also adds some documentation to explain the default behavior and how to change it.