### PR TITLE
Improve onChange async timing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "formifly",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "formifly",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/plugin-transform-runtime": "^7.16.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formifly",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "React form handling as light as a butterfly",
   "main": "dist/umd/formifly.js",
   "module": "dist/esm/index.js",

--- a/src/js/__tests__/components/demo/DemoForm.test.tsx
+++ b/src/js/__tests__/components/demo/DemoForm.test.tsx
@@ -3,7 +3,7 @@
  * Since it is encouraged to only write integration tests for react components, these tests should cover almost all of the react components.
  * It also serves as the place where the classes are integration tested in addition to their unit tests.
  */
-import {cleanup, fireEvent, render, screen} from '@testing-library/react';
+import {cleanup, fireEvent, render, screen, waitFor} from '@testing-library/react';
 import React from 'react';
 import DemoForm from '../../../components/demo/DemoForm';
 import {convertDateObjectToInputString} from '../../../helpers/generalHelpers';
@@ -124,7 +124,7 @@ describe('DemoForm', () => {
 
         fireEvent.click(secondOption);
         expect(firstOption.checked).toEqual(false);
-        expect(secondOption.checked).toEqual(true);
+        return waitFor(() => secondOption.checked);
     });
 
     it('renders a vertical radio group', () => {
@@ -138,11 +138,11 @@ describe('DemoForm', () => {
         expect(firstOption.checked).toEqual(false);
         expect(secondOption.checked).toEqual(true);
 
-        expect(
-            screen.getByText(
+        return expect(
+            screen.findByText(
                 'This radio group uses the FormiflyRadioGroup component, which creates an accessible field set to hold the options.',
             ),
-        ).not.toBeNull();
+        ).resolves.not.toBeNull();
     });
 
     it('renders a horizontal radio group', () => {
@@ -156,7 +156,7 @@ describe('DemoForm', () => {
         expect(firstOption.checked).toEqual(false);
         expect(secondOption.checked).toEqual(true);
 
-        expect(screen.getByText('Also select one of these horizontal fields please')).not.toBeNull();
+        return expect(screen.findByText('Also select one of these horizontal fields please')).resolves.not.toBeNull();
     });
 
     it('renders a functional multi select', () => {
@@ -188,7 +188,8 @@ describe('DemoForm', () => {
 
         fireEvent.click(trySelectingAll);
         fireEvent.click(screen.getByLabelText('Or try selecting all but one'));
-        expect(screen.getByText('All selected')).not.toBeNull();
+
+        return expect(screen.findByText('All selected')).resolves.not.toBeNull();
     });
 
     it('allows adding and removing fruit', () => {
@@ -222,7 +223,8 @@ describe('DemoForm', () => {
 
         expect(tastyCheck.checked).toBe(true);
         fireEvent.click(tastyCheck);
-        expect(tastyCheck.checked).toBe(false);
+
+        return waitFor(() => !tastyCheck.checked);
     });
 
     it('renders a form that can not be submitted while values are missing', () => {
@@ -257,6 +259,6 @@ describe('DemoForm', () => {
         const expiredCheck = screen.getByLabelText('Expired');
         fireEvent.click(expiredCheck);
         fireEvent.blur(expiredCheck);
-        expect(screen.getByText('You cannot add expired food.')).not.toBeNull();
+        return expect(screen.findByText('You cannot add expired food.')).resolves.not.toBeNull();
     });
 });

--- a/src/js/components/meta/FormiflyContext.tsx
+++ b/src/js/components/meta/FormiflyContext.tsx
@@ -127,23 +127,23 @@ export const FormiflyProvider = <T extends BaseValidator<any>>(props: FormiflyPr
         }
     };
 
-    const handleChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
-        setFieldValue(event.target.name, event.target.value);
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>): Promise<ValueOfValidator<T>> => {
+        return setFieldValue(event.target.name, event.target.value);
     };
 
     const handleCheckChange = (event: React.ChangeEvent<HTMLInputElement>): Promise<boolean> => {
-        setFieldValue(event.target.name, Boolean(event.target.checked));
-        return validateField(event.target.name, event.target.checked);
+        return setFieldValue(event.target.name, Boolean(event.target.checked))
+            .then(() => validateField(event.target.name, event.target.checked));
     };
 
     const handleRadioChange = (event: React.ChangeEvent<HTMLInputElement>): Promise<boolean> => {
-        setFieldValue(event.target.name, event.target.value);
-        return validateField(event.target.name, event.target.value);
+        return setFieldValue(event.target.name, event.target.value)
+            .then(() => validateField(event.target.name, event.target.value));
     };
 
     const handleMultiSelectChange = (name: string, newVal: Value): Promise<boolean> => {
-        setFieldValue(name, newVal);
-        return validateField(name, newVal);
+        return setFieldValue(name, newVal)
+            .then(() => validateField(name, newVal));
     };
 
     const handleBlur = (event: React.ChangeEvent<HTMLInputElement>): Promise<boolean> => {


### PR DESCRIPTION
This changes the handleChange functions to all return Promises which only resolve once the value has actually been changed.  
This change might break some tests that rely on very specific timing, but is not a real breaking change.