### PR TITLE
Make validateMultipleFields only set new errors to allow chaining multiple calls to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ REST backends.
     - [Creating empty array entries](#creating-empty-array-entries)
     - [Race condition when setting multiple child fields?](#race-condition-when-setting-multiple-child-fields)
     - [Race condition when validating multiple child fields?](#race-condition-when-validating-multiple-child-fields)
+    - [Helper functions exported by Formifly](#helper-functions-exported-by-formifly)
 10. [Development](#development)
 
 ## Quick Start
@@ -1395,6 +1396,21 @@ validateMultipleFields([['field1', 'valueOfField1'], ['field2']]);
 
 As you can see, the value is optional, but passing it improves performance of the function.  
 In any case, you will have to pass an array of arrays that contain at least the field names as their respective first entries.
+
+### Helper functions exported by Formifly
+
+Formifly exports some helper functions to help you work with it:
+
+- `convertDateObjectToInputString(date: Date)` Converts a date object to a string that can be used as the value for a datetime-local input
+  field.
+- `getFieldValueFromKeyString(keyString: string|number, values: Value|UnpackedErrors<any>)` Finds a field's value inside the formifly
+  values object by the key string.
+- `setFieldValueFromKeyString(keyString: string, value: Value, oldValues: T)` Sets a value within an object by its key string.
+- `containsValuesThatAreNotFalse(obj: any)` Checks to see if there is a value that is not false inside an object, checking all sub objects
+  and arrays. Useful for working with the Formifly `errors` object.
+- `findFieldValidatorFromName(name: string, shape?: ObjectValidator<any> | ArrayValidator<any> | BaseValidator<any>)` Finds the validator
+  for a specific key string within a shape
+- `unpackErrors(currentResult: ValidationResult<ValueOfValidator<T>>)` Turns a validation result into a valid Formifly `errors` object
 
 ## Development
 

--- a/src/js/components/meta/FormiflyContext.tsx
+++ b/src/js/components/meta/FormiflyContext.tsx
@@ -177,8 +177,8 @@ export const FormiflyProvider = <T extends BaseValidator<any>>(props: FormiflyPr
     const validateMultipleFields = (pairs: [string, Value?][]): Promise<boolean> => {
         return new Promise((resolve) => {
             let allValid = true;
-            let newTouched = touched;
-            let newErrors = errors;
+            let newTouched = {};
+            let newErrors = {};
             for (const pair of pairs) {
                 const name = pair[0];
                 const value = pair[1] ?? getFieldValueFromKeyString(name, values);
@@ -192,8 +192,13 @@ export const FormiflyProvider = <T extends BaseValidator<any>>(props: FormiflyPr
                 }
                 newTouched = setFieldValueFromKeyString(name, true, newTouched);
             }
-            setTouched(newTouched);
-            setErrors(newErrors);
+
+            setTouched((oldTouched) => {
+                return {...oldTouched as any, ...newTouched};
+            });
+            setErrors((oldErrors) => {
+                return {...oldErrors as any, ...newErrors};
+            });
             resolve(allValid);
         });
     };

--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -21,6 +21,7 @@ import {
     convertDateObjectToInputString,
     getFieldValueFromKeyString,
     setFieldValueFromKeyString,
+    containsValuesThatAreNotFalse,
 } from './helpers/generalHelpers';
 import {ensureValueIsDateObject, ensureValueIsNumeric, ensureValueIsRegexp} from './helpers/developerInputValidators';
 import withLabelErrorsAndHelp, {
@@ -64,6 +65,7 @@ export {
     convertDateObjectToInputString,
     getFieldValueFromKeyString,
     setFieldValueFromKeyString,
+    containsValuesThatAreNotFalse,
     ensureValueIsRegexp,
     ensureValueIsNumeric,
     ensureValueIsDateObject,


### PR DESCRIPTION
This is still not recommended since it will cause errors with more complicated data structures but for some cases with simple data, it works fine