### PR TITLE
improve typing of submit function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "formifly",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "formifly",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/plugin-transform-runtime": "^7.16.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formifly",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "React form handling as light as a butterfly",
   "main": "dist/umd/formifly.js",
   "module": "dist/esm/index.js",

--- a/src/js/__tests__/helpers/generalHelpers.test.ts
+++ b/src/js/__tests__/helpers/generalHelpers.test.ts
@@ -165,7 +165,7 @@ describe.each([
     [{fruit: []}, {fruit: null}, {fruit: []}, 'skips null values'],
 ])('Test completeDefaultValues', (validatorDefaults, userDefaults, expected, name) => {
     test(name, () => {
-        expect(completeDefaultValues(validatorDefaults, userDefaults)).toStrictEqual(expected);
+        expect(completeDefaultValues(validatorDefaults, userDefaults as any)).toStrictEqual(expected);
     });
 });
 

--- a/src/js/classes/ObjectValidator.ts
+++ b/src/js/classes/ObjectValidator.ts
@@ -40,8 +40,8 @@ class ObjectValidator<T extends ObjectValidatorFields> extends BaseValidator<Val
         mutationFunc?: MutationFunction,
         onError?: ErrorFunction,
         dependent?: Dependent,
-        dropEmpty = true,
-        dropNotInShape = false
+        dropEmpty: boolean = true,
+        dropNotInShape: boolean = false
     ) {
         const defaultValues = Object.fromEntries(
             Object.entries(fields).map(

--- a/src/js/components/demo/DemoForm.tsx
+++ b/src/js/components/demo/DemoForm.tsx
@@ -9,7 +9,7 @@ import StringValidator from '../../classes/StringValidator';
 import AutomagicFormiflyField from '../input/AutomagicFormiflyField';
 import {useFormiflyContext} from '../meta/FormiflyContext';
 import FormiflyForm from '../meta/FormiflyForm';
-import {Dependent, ErrorFunction, MutationFunction, Value} from '../../types';
+import {DeepPartial, Dependent, ErrorFunction, MutationFunction, ValueOfValidator} from '../../types';
 import DateValidator from '../../classes/DateValidator';
 
 const Button = styled.button`
@@ -181,7 +181,7 @@ const DemoForm = () => {
 
     const [successText, setSuccessText] = React.useState('');
 
-    const onSubmit = (values?: Value) => {
+    const onSubmit = (values: DeepPartial<ValueOfValidator<typeof validator>> | undefined) => {
         return new Promise<void>((resolve) => {
             setSuccessText(JSON.stringify(values));
             resolve();

--- a/src/js/components/meta/FormiflyContext.tsx
+++ b/src/js/components/meta/FormiflyContext.tsx
@@ -318,15 +318,7 @@ export const FormiflyProvider = <T extends ObjectValidator<any>>(props: Formifly
         return new Promise((resolve, reject) => {
             const result = shape.validate(values, values, values, t);
             if (result[0]) {
-                resolve(result[1] as DeepPartial<ValueOfValidator<T>> | undefined);
-                // I believe this cast is necessary because TypeScript doesn't support higher kinded types
-                // What that means is that the entire FormiflyProvider is defined with a generic extending
-                // BaseValidator<any>, when actually at runtime that any is a known type - but at compile time, it is
-                // treated as any, leading to the assumption that `result[1]` would be typed as
-                // ValueOfObjectValidatorFields<any>, which doesn't necessarily assignable to
-                // DeepPartial<ValueOfValidator<T>>.
-                // In this case, we do know that result[1] will be assignable to DeepPartial<ValueOfValidator<T>>,
-                // therefor we need the cast.
+                resolve(result[1]);
 
             } else {
                 reject(unpackErrors(result));

--- a/src/js/components/meta/FormiflyForm.tsx
+++ b/src/js/components/meta/FormiflyForm.tsx
@@ -54,7 +54,7 @@ const FormiflyForm = <T extends ObjectValidator<any>>(props: FormiflyFormProps<T
 };
 
 export type FormProps<T extends ObjectValidator<any>> = {
-    onSubmit: SubmitFunction;
+    onSubmit: SubmitFunction<T>;
     onSubmitValidationError?: SubmitValidationErrorFunction<T>;
     className?: string;
     children: (JSX.Element | false)[] | JSX.Element | false;

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -2,7 +2,7 @@ import type BaseValidator from './classes/BaseValidator';
 import type ObjectValidator from './classes/ObjectValidator';
 import type ArrayValidator from './classes/ArrayValidator';
 
-export type DeepPartial<T> = T extends object ? { [K in keyof T]?: DeepPartial<T[K]> } : T;
+export type DeepPartial<T> = { [K in keyof T]?: DeepPartial<T[K]> };
 
 export type SubmitFunction<Validator extends BaseValidator<any>> = (
     // todo: ideally only non-required values should be allowed to be undefined, but as that's harder to type,

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -4,7 +4,13 @@ import type ArrayValidator from './classes/ArrayValidator';
 
 export type DeepPartial<T> = T extends object ? { [K in keyof T]?: DeepPartial<T[K]> } : T;
 
-export type SubmitFunction = (_: Value | undefined, __: (___: any) => void) => Promise<void> | void;
+export type SubmitFunction<Validator extends BaseValidator<any>> = (
+    // todo: ideally only non-required values should be allowed to be undefined, but as that's harder to type,
+    //  this is good enough for now
+    values: DeepPartial<ValueOfValidator<Validator>> | undefined,
+    setErrors: (errors: UnpackedErrors<Validator>) => void
+) => Promise<void> | void;
+
 export type SubmitValidationErrorFunction<T extends BaseValidator<any>> =
     undefined | ((errors: UnpackedErrors<T>, reason: UnpackedErrors<T>) => void);
 


### PR DESCRIPTION
The SubmitFunction type wasn't typed much at all so far. With submit functions being an interface that is relevant to users of formifly, it made sense to improve typing of that function.

It isn't perfect yet as fields that are marked as required will be considered optional in terms of the type of the first parameter of submit functions. Ideally, the typing would mark required fields as such in the value passed to the submit function. As (at least theoretically) the requirement of fields can change at runtime and the typing is evaluated at compile type, I am not sure if it's possible to create a type that marks only non-required fields as optional.
Still, having at least a DeepPartial-typed value to work with when writing submit functions is better than the previous any-type.